### PR TITLE
Perform session redirect from environment variable

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,13 +9,13 @@ class SessionsController < ApplicationController
     auth = request.env["omniauth.auth"]     
     user = User.find_by_provider_and_uid(auth["provider"], auth["uid"]) || User.create_with_omniauth(auth)
     session[:user_id] = user.id
-    redirect_to "http://vm344a.se.rit.edu/", :notice => "Signed in!"
+    redirect_to ENV["YOLO_SESSION_REDIRECT_URL"], :notice => "Signed in!"
   end
 
   # destroy a session
   def destroy
     session[:user_id] = nil
-    redirect_to "http://vm344a.se.rit.edu/", :notice => "Signed out!"
+    redirect_to ENV["YOLO_SESSION_REDIRECT_URL"], :notice => "Signed out!"
   end
 
   # verify the user is authenticated


### PR DESCRIPTION
Add the following to your local .bash_profile:

export YOLO_SESSION_REDIRECT_URL="http://localhost/"

The old url pointing to http://vm344a.se.rit.edu/ has already been set on production
